### PR TITLE
Set level of SA1516 to error

### DIFF
--- a/SfwStyleCop.ruleset
+++ b/SfwStyleCop.ruleset
@@ -122,7 +122,7 @@
     <Rule Id="SA1513" Action="Error" />
     <Rule Id="SA1514" Action="Error" />
     <Rule Id="SA1515" Action="None" />
-    <Rule Id="SA1516" Action="None" />
+    <Rule Id="SA1516" Action="Error" />
     <Rule Id="SA1517" Action="Error" />
     <Rule Id="SA1518" Action="Error" />
     <Rule Id="SA1519" Action="Error" />


### PR DESCRIPTION
[SA1516](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1516.md) enforces a blank line between C# elements.